### PR TITLE
Use wp_safe_redirect

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -14,7 +14,7 @@ function wpfssl_core(){
 
 if ( FORCE_SSL && !is_ssl () )
  {
-  wp_redirect('https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 301 );
+  wp_safe_redirect('https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 301 );
   exit();
  }
 }


### PR DESCRIPTION
`wp_safe_redirect` works the same as `wp_redirect`, but ensures the redirect will be to an allowed host—in this case, since the redirect is to an HTTPS version of the site's own URLs, that will work all of the time. It's just one additional layer of protection to prevent this redirect from being exploited.